### PR TITLE
Fire `LspProgressUpdate` autocmd

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -386,6 +386,7 @@ local function handle_progress(err, msg, info)
   vim.schedule(function()
     fidget:fmt()
   end)
+  vim.api.nvim_command("doautocmd <nomodeline> User LspProgressUpdate")
 end
 
 function M.is_installed()


### PR DESCRIPTION
Neovim's LSP client's builtin `$/progress` handler [fires](https://github.com/neovim/neovim/blob/b08cf73be959397b5715395f1465fb76a76a6a05/runtime/lua/vim/lsp/handlers.lua#L24-L63) the [`LspProgressUpdate` autocommand](https://neovim.io/doc/user/lsp.html#LspProgressUpdate) at the end. This plugin should too, I believe?